### PR TITLE
商品出品ページ編集機能

### DIFF
--- a/app/assets/javascripts/modules/product.js
+++ b/app/assets/javascripts/modules/product.js
@@ -16,14 +16,9 @@ $(document).on('turbolinks:load', ()=> {
     const html = `
                 <div class="preview-box" id="preview-box__${index}">
                   <div class= "upper-box">
-                    <img data-index="${index}" src="${url}" width="110px" height="150px", class="preview-image", alt="preview">
+                    <img data-index="${index}" src="${url}" class="preview-image", alt="preview">
                   </div>
                   <div class="lower-box">
-                    <div class="update-box">
-                      <label data-index="${index}" class="js-file_group" for="product_images_attributes_${index}_src">編集
-                        <input class="js-file" type="file", name="product[images_attributes][${index}][src]", id="product_images_attributes_${index}_src">
-                      </label>
-                    </div>
                     <div class="delete-box" id="delete_btn_${index}">
                       <span>削除</span>
                     </div>
@@ -66,6 +61,7 @@ $(document).on('turbolinks:load', ()=> {
         $('#label').css("display","none");
         $(`.label-content-${targetIndex}`).css("display","none");
         $(`.label-content-small-${targetIndex}`).css("display","none");
+        $('.label-content-edit__add').css("display", "none")
       }
       if ($('#labels div').length < 5) {
         $('#labels').append(buildFileField(fileIndex[0]));
@@ -78,24 +74,34 @@ $(document).on('turbolinks:load', ()=> {
   $(document).on('click', '.delete-box', function() {
     var id = $(this).attr('id').replace(/[^0-9]/g, '');
 
-    if ($('#labels div').length != 0){
+    if ($('#labels div').length == $('.preview-box').length){
       $(`#preview-box__${id}`).remove();
       $(`#product_images_attributes_${id}_src`).val("");
       $(`.label-content-${id}`).remove();
+      $(`.label-content-small-${id}`).remove();
       $('#labels').append(buildSmallFileField(id));
-    } else{
+    } else {
       $(`#preview-box__${id}`).remove();
       $(`#product_images_attributes_${id}_src`).val("");
       $(`.label-content-${id}`).remove();
+      $(`.label-content-small-${id}`).remove();
     }
+  });
 
-    const targetIndex = $(this).parent().data('index');
+  $(document).on('click','.delete-box-edit', function(){
+    const targetIndex = $(this).attr('id').replace(/[^0-9]/g, '');
     const hiddenCheck = $(`input[data-index="${targetIndex}"].hidden-destroy`);
 
     if (hiddenCheck) hiddenCheck.prop('checked', true);
 
-    $(this).parent().remove();
     $(`img[data-index="${targetIndex}"]`).remove();
+    $(`#preview-box__${targetIndex}`).remove();
+    $(`.label-content-${targetIndex}`).appendTo('#deleted');
+    if ($('#labels div').length == $('.preview-box').length){
+      $('#labels').append(buildSmallFileField(targetIndex + 1));
+    }
 
+
+    if ($('#labels div').length == 0) $('#labels').append(buildFileField(fileIndex[0]));
   });
 });

--- a/app/assets/stylesheets/modules/products/new.scss
+++ b/app/assets/stylesheets/modules/products/new.scss
@@ -45,43 +45,41 @@
             display: block;
             flex-wrap: nowrap;
             display: flex;
+            max-width: 100%;
             #previews{
               display: flex;
               .preview-box{
                 height: 162px;
-                width: 118px;
+                width: 114px;
                 margin: 0 10px 10px 0;
                 .upper-box{
-                  height: 112px;
+                  height: 122px;
                   width: 100%;
                   img{
-                    width:112px;
-                    height: 112px;
+                    width:100%;
+                    height: 122px;
                   }
                 }
                 .lower-box{
                   display: flex;
                   text-align: center;
-                  .update-box{
+                  .delete-box{
                     color:  #3ccace;
-                    width: 46%;
-                    height: 50px;
-                    line-height: 50px;
+                    width: 100%;
+                    height: 40px;
+                    line-height: 40px;
                     border: 1px solid #eeeeee;
                     background-color: #f5f5f5;
                     cursor: pointer;
                     .js-file_group{
                       cursor: pointer;
                     }
-                    .js-file{
-                      display: none;
-                    }
                   }
-                  .delete-box{
+                  .delete-box-edit{
                     color:  #3ccace;
-                    width: 46%;
-                    height: 50px;
-                    line-height: 50px;
+                    width: 100%;
+                    height: 40px;
+                    line-height: 40px;
                     border: 1px solid #eeeeee;
                     background-color: #f5f5f5;
                     cursor: pointer;
@@ -95,10 +93,10 @@
             #labels{
               display: flex;
               max-width: 100%;
-              .label-content-4, .label-content-0, .label-content-2, .label-content-1, .label-content-3, .label-content-5, .label-content-6, .label-content-7, .label-content-8, .label-content-9{
+              #label{
                 margin-bottom: 10px;
                 margin-right: 10px;
-                width: 118px;
+                width: 114px;
                 height: 162px;
                 .js-file_group{
                   display: block;
@@ -124,7 +122,7 @@
                   .label-box__text-visible{
                     position: absolute;
                     top: 50px;
-                    left: 12px;
+                    left: 5px;
                     text-align: center;
                     font-size: 1px;
                     line-height: 1.5;
@@ -143,10 +141,10 @@
                   }
                 }
               }
-              .label-content-small-0 ,.label-content-small-1,.label-content-small-2, .label-content-small-3, .label-content-small-4, .label-content-small-5, .label-content-small-6, .label-content-small-7,.label-content-small-8, .label-content-small-9{
+              #label{
                 margin-bottom: 10px;
                 margin-right: 10px;
-                width: 118px;
+                width: 114px;
                 height: 162px;
                 .js-file_group{
                   display: block;
@@ -172,7 +170,7 @@
                   .label-box__text-visible{
                     position: absolute;
                     top: 50px;
-                    left: 12px;
+                    left: 5px;
                     text-align: center;
                     font-size: 1px;
                     line-height: 1.5;
@@ -191,6 +189,12 @@
                   }
                 }
               }
+              #label_edit{
+                display: none;
+              }
+            }
+            #deleted{
+              display:none;
             }
           }
         }

--- a/app/controllers/products_controller.rb
+++ b/app/controllers/products_controller.rb
@@ -34,9 +34,16 @@ class ProductsController < ApplicationController
   end
 
   def edit
+    @category_grandchild = @product.category
+    @category_child = @category_grandchild.parent
+    @category_parent = @category_child.parent
+    @category_parent_array = Category.where(ancestry: nil)
+    @category_children_edit = Category.find_by(id: @category_parent.id).children
+    @category_grandchildren_edit = Category.find_by(id: @category_child.id ).children
   end
 
   def update
+    @category_parent_array = Category.where(ancestry: nil)
     if @product.update(product_params)
       redirect_to root_path
     else

--- a/app/controllers/products_controller.rb
+++ b/app/controllers/products_controller.rb
@@ -2,6 +2,7 @@ class ProductsController < ApplicationController
   before_action :set_product, only: [:show, :edit, :update, :destroy]
   before_action :authenticate_user!, except: [:index,:show ]
   before_action :set_parents, only: [:index,  :new, :create, :edit, :show]
+  before_action :set_parent_array, only: [:new, :create, :edit, :update]
 
   def index
     @products = Product.includes(:images).order('created_at DESC')
@@ -10,13 +11,11 @@ class ProductsController < ApplicationController
   def new
     @product = Product.new
     @product.images.new
-    @category_parent_array = Category.where(ancestry: nil)
   end
 
 
   def create
     @product = Product.new(product_params)
-    @category_parent_array = Category.where(ancestry: nil)
     if @product.save
       redirect_to product_path(params[:id])
     else
@@ -37,13 +36,11 @@ class ProductsController < ApplicationController
     @category_grandchild = @product.category
     @category_child = @category_grandchild.parent
     @category_parent = @category_child.parent
-    @category_parent_array = Category.where(ancestry: nil)
     @category_children_edit = Category.find_by(id: @category_parent.id).children
     @category_grandchildren_edit = Category.find_by(id: @category_child.id ).children
   end
 
   def update
-    @category_parent_array = Category.where(ancestry: nil)
     if @product.update(product_params)
       redirect_to product_path(params[:id])
     else
@@ -86,6 +83,10 @@ class ProductsController < ApplicationController
 
   def set_parents
     @parents = Category.where(ancestry: nil)
+  end
+
+  def set_parent_array
+    @category_parent_array = Category.where(ancestry: nil)
   end
 
 end

--- a/app/controllers/products_controller.rb
+++ b/app/controllers/products_controller.rb
@@ -18,7 +18,7 @@ class ProductsController < ApplicationController
     @product = Product.new(product_params)
     @category_parent_array = Category.where(ancestry: nil)
     if @product.save
-      redirect_to root_path
+      redirect_to product_path(params[:id])
     else
       render new_product_path
     end
@@ -45,7 +45,7 @@ class ProductsController < ApplicationController
   def update
     @category_parent_array = Category.where(ancestry: nil)
     if @product.update(product_params)
-      redirect_to root_path
+      redirect_to product_path(params[:id])
     else
       render :edit
     end

--- a/app/models/product.rb
+++ b/app/models/product.rb
@@ -1,5 +1,4 @@
 class Product < ApplicationRecord
-  belongs_to :user
   belongs_to :category
   belongs_to :saler, class_name: "User"
   belongs_to :buyer, class_name: "User", optional: true

--- a/app/models/product.rb
+++ b/app/models/product.rb
@@ -1,4 +1,5 @@
 class Product < ApplicationRecord
+  belongs_to :user
   belongs_to :category
   belongs_to :saler, class_name: "User"
   belongs_to :buyer, class_name: "User", optional: true

--- a/app/views/products/_form.html.haml
+++ b/app/views/products/_form.html.haml
@@ -12,11 +12,15 @@
             最大５枚までアップロード出来ます
             #image-box
               #previews
+                -if @product.persisted?
+                  - @product.images.each_with_index do |image, i|
+                    #preview-box.preview-box
+                      .upper-box
+                        = image_tag image.src.url, data: { index: i}, width: "110px", height: "150px", class:"preview-image",alt:"preview"
+                      .lower-box
+                        .update-box
               #labels
                 #label.label-content-0
-                  -if @product.persisted?
-                    - @product.images.each_with_index do |image, i|
-                      = image_tag image.src.url, data: { index: i}, width: "100", height: "100"
                   = f.fields_for :images do |image|
                     = image.label :src ,{id:"label-box--#{image.index}", class:"js-file_group", "data-index" => "#{image.index}"} do
                       =icon("fas","camera",class: "label-box-icon")
@@ -47,9 +51,20 @@
               = f.label :category_id ,class: 'listing-default__label' do
                 カテゴリー
                 %span.require 必須
-              .listing-select-wrapper
-                .listing-select-wrapper__box
-                  =f.collection_select :category_id, @category_parent_array, :id, :name, { include_blank: "選択してください"}, { class: "listing-select-wrapper__box--select", id: "parent_category"}
+              - if @product.persisted?
+                .listing-select-wrapper
+                  .listing-select-wrapper__box
+                    =f.collection_select :category_id, @category_parent_array, :id, :name, { include_blank: "選択してください", selected: @category_parent.id}, { class: "listing-select-wrapper__box--select", id: "parent_category"}
+                #children_wrapper.listing-select-wrapper__added
+                  .listing-select-wrapper__box
+                    =f.select :category_id, options_for_select(@category_children_edit.map{|c|[c[:name],c[:id],{'data-category'=>c[:id]}]}, @category_child.id),{},{class:"listing-select-wrapper__box--select", id: "child_category"}
+                #grandchildren_wrapper.listing-select-wrapper__added
+                  .listing-select-wrapper__box
+                    =f.collection_select :category_id, @category_grandchildren_edit, :id, :name, { include_blank: "選択してください",selected: @category_grandchild.id },{class: "listing-select-wrapper__box--select", id: "grandchild_category"}
+              - else
+                .listing-select-wrapper
+                  .listing-select-wrapper__box
+                    =f.collection_select :category_id, @category_parent_array, :id, :name, { include_blank: "選択してください"}, { class: "listing-select-wrapper__box--select", id: "parent_category"}
           .new-product-text
             =f.label :brand, class:"new-product-text-title" do
               ブランド

--- a/app/views/products/_form.html.haml
+++ b/app/views/products/_form.html.haml
@@ -10,28 +10,41 @@
             %span.require 必須
           %p.image-upload-info
             最大５枚までアップロード出来ます
-            #image-box
-              #previews
-                -if @product.persisted?
+            - if @product.persisted?
+              #image-box
+                #previews
                   - @product.images.each_with_index do |image, i|
-                    #preview-box.preview-box
+                    .preview-box{id: "preview-box__#{i}"}
                       .upper-box
-                        = image_tag image.src.url, data: { index: i}, width: "110px", height: "150px", class:"preview-image",alt:"preview"
+                        = image_tag image.src.url, data: { index: i}, class:"preview-image",alt:"preview"
                       .lower-box
-                        .update-box
-              #labels
-                #label.label-content-0
+                        .delete-box-edit{id:"delete_btn_#{i}"}
+                          %span 削除
+                #labels
                   = f.fields_for :images do |image|
-                    = image.label :src ,{id:"label-box--#{image.index}", class:"js-file_group", "data-index" => "#{image.index}"} do
-                      =icon("fas","camera",class: "label-box-icon")
-                      %pre.label-box__text-visible クリックしてアップロード
-                      = image.file_field :src, class: 'js-file'
-                    - if @product.persisted?
-                      = image.check_box :_destroy, data:{ index: image.index }, class: 'hidden-destroy'
-                  - if @product.persisted?
-                    .js-file_group{"data-index" => "#{@product.images.count}"}
-                      = file_field_tag :src, name: "product[images_attributes][#{@product.images.count}][src]", class: "js-file"
-                      .js-remove 削除
+                    #label_edit{class: "label-content-#{image.index}"}
+                      = image.label :src ,{id:"label-box--#{image.index}", class:"js-file_group", "data-index" => "#{image.index}"} do
+                        =icon("fas","camera",class: "label-box-icon")
+                        %pre.label-box__text-visible クリックしてアップロード
+                        = image.file_field :src, class: 'js-file', name: "product[images_attributes][#{image.index}][src]"
+                        = image.check_box :_destroy, data:{ index: image.index}, class:'hidden-destroy'
+                  -if @product.images.count < 5
+                    #label.label-content-edit__add
+                      %label.js-file_group{"data-index" => "#{@product.images.count}",id:"label_box--#{@product.images.count}"}
+                        =icon("fas","camera",class: "label-box-icon")
+                        %pre.label-box__text-visible クリックしてアップロード
+                        = file_field_tag :src , name: "product[images_attributes][#{@product.images.count}][src]", class:"js-file"
+                #deleted
+            - else
+              #image-box
+                #previews
+                #labels
+                  #label.label-content-0
+                    = f.fields_for :images do |image|
+                      = image.label :src ,{id:"label-box--#{image.index}", class:"js-file_group", "data-index" => "#{image.index}"} do
+                        =icon("fas","camera",class: "label-box-icon")
+                        %pre.label-box__text-visible クリックしてアップロード
+                        = image.file_field :src, class: 'js-file'
         .new-product-form__box
           %p.new-product-form__sub
           .new-product-text
@@ -101,4 +114,7 @@
             %span.price-mark ¥
             =f.text_field :price, class: "new-product-text-price__input-price",placeholder:"例)300"
         .new-product-btn
-          =f.submit "出品する",class:"new-product-btn-green"
+          -if @product.persisted?
+            =f.submit "編集する", class: "new-product-btn-green"
+          -else
+            =f.submit "出品する",class:"new-product-btn-green"

--- a/app/views/products/edit.html.haml
+++ b/app/views/products/edit.html.haml
@@ -1,7 +1,7 @@
 .header
   = render "header"
 .main
-  =render 'form'
+  = render "form"
 
 %aside.appBanner
   = render "aside"

--- a/spec/models/product_spec.rb
+++ b/spec/models/product_spec.rb
@@ -91,11 +91,96 @@ describe Product do
       expect(product.errors[:content]).to include("is too long (maximum is 1000 characters)")
     end
 
-    it 'is invalid without images' do
+  end
+
+  describe '#update' do
+
+    it "is valid with name,content,category_id, send_from, delivery_fee, delivery_date, condition, brand, price, user_id, saler_id, image" do
       product = build(:product)
-      image =build(:image, src:"")
+      expect(product).to be_valid
+    end
+
+    it "is vslid without brand" do
+      product = build(:product, brand:"")
+      expect(product).to be_valid
+    end
+
+    it "is invalid without name" do
+      product = build(:product, name:"")
       product.valid?
-      expect(product.errors[:image]).to include("is invalid")
+      expect(product.errors[:name]).to include("can't be blank")
+    end
+
+    it "is invalid without content" do
+      product = build(:product, content:"")
+      product.valid?
+      expect(product.errors[:content]).to include("can't be blank")
+    end
+
+    it "is invalid without condition" do
+      product = build(:product, condition:"")
+      product.valid?
+      expect(product.errors[:condition]).to include("can't be blank")
+    end
+
+    it "is invalid without send_from" do
+      product = build(:product, send_from:"")
+      product.valid?
+      expect(product.errors[:send_from]).to include("can't be blank")
+    end
+
+    it "is invalid without delivery_fee" do
+      product = build(:product, delivery_fee:"")
+      product.valid?
+      expect(product.errors[:delivery_fee]).to include("can't be blank")
+    end
+
+    it "is invalid without delivery_date" do
+      product = build(:product, delivery_date:"")
+      product.valid?
+      expect(product.errors[:delivery_date]).to include("can't be blank")
+    end
+
+    it "is invalid without price" do
+      product = build(:product, price:"")
+      product.valid?
+      expect(product.errors[:price]).to include("can't be blank")
+    end
+
+    it "is invalid without saler" do
+      product = build(:product, saler_id:"")
+      product.valid?
+      expect(product.errors[:saler]).to include("must exist")
+    end
+
+    it "is invalid that price is more than ¥10000000" do
+      product = build(:product, price:"10000001")
+      product.valid?
+      expect(product.errors[:price]).to include("must be less than 10000000")
+    end
+
+    it "is invalid that price is less than ¥300" do
+      product = build(:product, price:"299")
+      product.valid?
+      expect(product.errors[:price]).to include("must be greater than 300")
+    end
+
+    it "is invalid that price is not integer" do
+      product = build(:product, price:"千円")
+      product.valid?
+      expect(product.errors[:price]).to include("is not a number")
+    end
+
+    it "is invalid with name that is more than 40 chracters" do
+      product = build(:product, name: Faker::Lorem.characters(number: 41))
+      product.valid?
+      expect(product.errors[:name]).to include("is too long (maximum is 40 characters)")
+    end
+
+    it "is invalid that content is more than 1000 characters" do
+      product = build(:product, content: Faker::Lorem.characters(number: 1001))
+      product.valid?
+      expect(product.errors[:content]).to include("is too long (maximum is 1000 characters)")
     end
 
   end


### PR DESCRIPTION
* What
  * 最終課題フリーマーケットアプリケーション
  * 商品編集機能
  * 商品編集ページを開いた時点で、元の情報が全て表示されている。
     * 商品詳細ページ [Gyazo Gif](https://gyazo.com/32a0c3194e0a85718fd333ac485ed1b8)
     * 商品編集ページ [Gyazo Gif](https://gyazo.com/269220da6d8ef1018bd4a3483b782049)
  * 写真も削除することが出来ており、代わりの写真を追加することも出来ます。
     * 写真削除から追加 [Gyazo Gif](https://gyazo.com/d3da998517d13fd86c808bed6ecada21)
     * 編集後の詳細ページ [Gyazo](https://gyazo.com/ad72c9137e510309dda39e40fd9b2e4a)
  * カテゴリーのセレクトボックスの変更にも対応しております。
     * 編集ページでのカテゴリーの変更 [Gyazo Gif](https://gyazo.com/a58272fb13a31fd4fa52dd206b1fa326)
  * createアクションの際と同様の単体テストを実施済み
  * newテンプレートとeditテンプレートに関しては、_formという部分テンプレートを使用しており、@product.persisted?にて条件分岐を行っております。
  * **コードレビューをよろしくお願いします。**

* Why
  * 次の開発に進んでもよいかの確認となります。