### PR TITLE
【サーバサイド】パンくず

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -77,3 +77,4 @@ group :production do
   gem 'unicorn'
 end
 gem 'payjp'
+gem "gretel"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -146,6 +146,8 @@ GEM
     formatador (0.2.5)
     globalid (0.4.2)
       activesupport (>= 4.2.0)
+    gretel (4.0.1)
+      rails (>= 5.1)
     haml (5.1.2)
       temple (>= 0.8.0)
       tilt
@@ -374,6 +376,7 @@ DEPENDENCIES
   faker
   fog-aws
   font-awesome-sass
+  gretel
   haml-rails (>= 1.0, <= 2.0.1)
   jbuilder (~> 2.7)
   jquery-rails

--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -24,3 +24,4 @@
 @import "modules/purchases/buy";
 @import "modules/purchases/pay";
 @import "modules/categories/index.scss";
+@import "modules/breadcrumbs/breadcrumbs";

--- a/app/assets/stylesheets/modules/breadcrumbs/breadcrumbs.scss
+++ b/app/assets/stylesheets/modules/breadcrumbs/breadcrumbs.scss
@@ -1,0 +1,17 @@
+.breadcrumbs{
+  border-top: 1px solid #eee;
+  border-bottom: 1px solid #eee;
+  .breadcrumbs-list{
+    font-size: 14px;
+    margin: 0 30px;
+    padding: 16px 0;
+    overflow: visible;
+    a{
+      text-decoration: none;
+      color: #272727;
+    }
+    .current{
+      font-weight: bold;
+    }
+  }
+}

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -1,16 +1,10 @@
 class UsersController < ApplicationController
   before_action :set_user, only: [:show, :destroy]
   before_action :authenticate_user!, only: [:show]
-
+  before_action :set_parents, only: [:show]
 
   def destroy
     user.destroy
-  end
-
-  def show
-    unless @user == current_user
-      redirect_to root_path(@user)
-    end
   end
 
   def show
@@ -27,5 +21,9 @@ class UsersController < ApplicationController
 
   def set_user
     @user = User.find(params[:id])
+  end
+
+  def set_parents
+    @parents = Category.where(ancestry: nil)
   end
 end

--- a/app/views/card/new.html.haml
+++ b/app/views/card/new.html.haml
@@ -1,6 +1,7 @@
 .index-header
   = render "Purchase-header"
-
+- breadcrumb :card
+= render "layouts/breadcrumbs"
 .card_add 
   .card_add-box
     .title クレジットカード情報入力

--- a/app/views/categories/index.html.haml
+++ b/app/views/categories/index.html.haml
@@ -1,5 +1,7 @@
 .header
   = render "products/header"
+- breadcrumb :categories
+= render "layouts/breadcrumbs"
 
 .category__container
   .category__container--top

--- a/app/views/devise/registrations/edit.html.haml
+++ b/app/views/devise/registrations/edit.html.haml
@@ -2,7 +2,8 @@
   .Header__inner
     =link_to root_path ,class:"LogoFurima__link" do
       =image_tag "logo.png",class:"LogoFurima__image"
-
+- breadcrumb :user
+= render "layouts/breadcrumbs"
 .Account
   %section.Account__container
     %nav.progress-bar

--- a/app/views/devise/registrations/edit_address.html.haml
+++ b/app/views/devise/registrations/edit_address.html.haml
@@ -2,6 +2,8 @@
   .Header__inner
     =link_to root_path ,class:"LogoFurima__link" do
       =image_tag "logo.png",class:"LogoFurima__image"
+- breadcrumb :user_address
+= render "layouts/breadcrumbs"
       
 .Account
   %section.Account__container

--- a/app/views/layouts/_breadcrumbs.html.haml
+++ b/app/views/layouts/_breadcrumbs.html.haml
@@ -1,0 +1,2 @@
+.breadcrumbs
+  = breadcrumbs pretext: "",separator: " &rsaquo; ", class: "breadcrumbs-list"

--- a/app/views/products/new.html.haml
+++ b/app/views/products/new.html.haml
@@ -1,5 +1,7 @@
 .header
   = render "header"
+- breadcrumb :new_product
+= render "layouts/breadcrumbs"
 .main
   = render "form"
 %aside.appBanner

--- a/app/views/users/_mypage-side.html.haml
+++ b/app/views/users/_mypage-side.html.haml
@@ -4,7 +4,7 @@
       =link_to edit_user_registration_path(current_user), class:"MyPage__link" do
         本人情報
     %li.MyPage__list
-      =link_to "#", class:"MyPage__link" do
+      =link_to new_product_path, class:"MyPage__link" do
         商品を出品する
     %li.MyPage__list
       =link_to "#", class:"MyPage__link" do
@@ -16,5 +16,5 @@
       =link_to "#", class:"MyPage__link" do
         購入した商品
     %li.MyPage__list
-      =link_to "#", class:"MyPage__link" do
+      =link_to card_index_path, class:"MyPage__link" do
         クレジットカード情報

--- a/app/views/users/show.html.haml
+++ b/app/views/users/show.html.haml
@@ -1,6 +1,7 @@
 .header
   = render 'products/header'
-
+- breadcrumb :mypage
+= render "layouts/breadcrumbs"
 .MyPage
   = render 'mypage-side'
   .MyPage__main

--- a/config/breadcrumbs.rb
+++ b/config/breadcrumbs.rb
@@ -16,28 +16,16 @@ crumb :user_address do
   parent :user
 end
 
+crumb :new_product do
+  link "商品を出品する", new_product_path
+  parent :mypage
+end
 
-# crumb :projects do
-#   link "Projects", projects_path
-# end
+crumb :card do
+  link "クレジットカード情報", card_index_path
+  parent :mypage
+end
 
-# crumb :project do |project|
-#   link project.name, project_path(project)
-#   parent :projects
-# end
-
-# crumb :project_issues do |project|
-#   link "Issues", project_issues_path(project)
-#   parent :project, project
-# end
-
-# crumb :issue do |issue|
-#   link issue.title, issue_path(issue)
-#   parent :project_issues, issue.project
-# end
-
-# If you want to split your breadcrumbs configuration over multiple files, you
-# can create a folder named `config/breadcrumbs` and put your configuration
-# files there. All *.rb files (e.g. `frontend.rb` or `products.rb`) in that
-# folder are loaded and reloaded automatically when you change them, just like
-# this file (`config/breadcrumbs.rb`).
+crumb :categories do
+  link "カテゴリー一覧", categories_path
+end

--- a/config/breadcrumbs.rb
+++ b/config/breadcrumbs.rb
@@ -1,0 +1,43 @@
+crumb :root do
+  link "トップページ", root_path
+end
+
+crumb :mypage do
+  link "マイページ", user_path(current_user)
+end
+
+crumb :user do
+  link "本人情報", edit_user_registration_path
+  parent :mypage
+end
+
+crumb :user_address do
+  link "送付先住所", addresses_path
+  parent :user
+end
+
+
+# crumb :projects do
+#   link "Projects", projects_path
+# end
+
+# crumb :project do |project|
+#   link project.name, project_path(project)
+#   parent :projects
+# end
+
+# crumb :project_issues do |project|
+#   link "Issues", project_issues_path(project)
+#   parent :project, project
+# end
+
+# crumb :issue do |issue|
+#   link issue.title, issue_path(issue)
+#   parent :project_issues, issue.project
+# end
+
+# If you want to split your breadcrumbs configuration over multiple files, you
+# can create a folder named `config/breadcrumbs` and put your configuration
+# files there. All *.rb files (e.g. `frontend.rb` or `products.rb`) in that
+# folder are loaded and reloaded automatically when you change them, just like
+# this file (`config/breadcrumbs.rb`).


### PR DESCRIPTION
#what
パンくずの実装。現状、本人情報、商品を出品する、クレジットカード情報、カテゴリー一覧からのパンくずのみ実装。
※多階層のカテゴリー表示はカテゴリー詳細ページができてから実装。
https://gyazo.com/0ddcb15b111a90813d0b1a0a3b800b1f
#why
Webサイトを訪れたユーザが今どこにいるかを視覚的にわかりやすくするため。