### PR TITLE
show→category_show

### DIFF
--- a/app/assets/stylesheets/modules/products/show.scss
+++ b/app/assets/stylesheets/modules/products/show.scss
@@ -321,59 +321,72 @@
         position: relative;
       }
       .related-items-list{
-        .related-item{
-          margin-bottom: 10px;
-          float: left;
-          width: calc( 700px / 3 );
-          background-color: #ffffff;
-          .related-item-link{
+        overflow: scroll;
+        position: relative;
+        display: grid;
+        grid-template-columns: repeat(3, 1fr);
+        grid-column-gap: 5px;
+        grid-row-gap: 5px;
+        .pickupCategory-list__list{
+          background-color: #fff;
+          margin: 0 5px;
+          width: 200px;
+          .pickupCategory-list-tag__sold{
+            width: 0;
+            height: 0;
+            border-width: 80px 80px 0 0;
+            border-color: #ea352d transparent transparent transparent;
             display: block;
-            margin: 24px 0 8px;
-            color: #3ccace;
-            text-decoration: none;
-            font-weight: bold;
-            font-size: 22px;
-            position: relative;
-            .related-item-image-field{
-              width: 220px;
-              height: 150px;
-              position: relative;
-              overflow: hidden;
-              margin: 0;
-              z-index: auto;
-              .related-item-image{
-                position: absolute;
-                width: 100%;
-                z-index: auto;
-                height: 150px;
-                object-fit: cover;
-              }
+            position: absolute;
+            z-index: 1;
+            border-style: solid;
+            &__inner{
+              top: -60px;
+              font-size: 20px;
+              position: absolute;
+              left: 0;
+              z-index: 2;
+              color: #fff;
+              transform: rotate(-45deg);
+              letter-spacing: 2px;
+              font-weight: 600;
             }
-            .related-item-body{
-              background-color: #ffffff;
-              color: #333333;
-              padding: 16px;
+          }
+          .pickupCategory-list-image{
+            width: 100%;
+            height: 150px;
+          }
+          .pickupCategory-list-body{
+            background-color: white;
+            color: #333;
+            padding: 16px;
+            .pickupCategory-list-name{
+              overflow: hidden;
               line-height: 1.5;
               font-size: 16px;
               text-align: left;
-              overflow: hidden;
             }
-            .related-item-detail{
+            .pickupCategory-list-evaluation{
               font-size: 16px;
-              color: black;
-              .detail-list{
+              ul{
                 display: flex;
                 align-items: center;
                 justify-content: space-between;
+                .fa{
+                  display: inline-block;
+                  font-size: inherit;
+                  text-rendering: auto;
+                  -webkit-font-smoothing: antialiased;
+                }
               }
-              .tax{
+              p{
                 font-size: 10px;
                 text-align: left;
+              }
               }
             }
           }
         }
       }
-    }
   }
 }

--- a/app/controllers/products_controller.rb
+++ b/app/controllers/products_controller.rb
@@ -2,7 +2,7 @@ class ProductsController < ApplicationController
   before_action :set_product, only: [:show, :edit, :update, :destroy]
   before_action :authenticate_user!, except: [:index,:show ]
   before_action :set_parents, only: [:index,  :new, :create, :edit, :show, :search]
-  before_action :set_parent_array, only: [:new, :create, :edit, :update, :search]
+  before_action :set_parent_array, only: [:new, :create, :edit, :update, :search, :show]
 
   def index
     @products = Product.includes(:images).order('created_at DESC').limit(5)
@@ -50,13 +50,13 @@ class ProductsController < ApplicationController
 
   def show
     @user = @product.user
-    @product = Product.find(params[:id])
     @category_id = @product.category_id
     @category_parent = Category.find(@category_id).parent.parent
     @category_child = Category.find(@category_id).parent
     @category_grandchild = Category.find(@category_id)
     @images = @product.images
     @images_first = @product.images.first
+    @products = Product.includes(:images).order('created_at DESC') .where.not(id:@product.id)
   end
 
   def get_category_children_form

--- a/app/views/products/_header.html.haml
+++ b/app/views/products/_header.html.haml
@@ -21,17 +21,17 @@
             %ul.category__parent.category__list
               - @parents.each do |parent|
                 %li
-                  = link_to "", class: "category__parent--name" do
+                  = link_to category_path(parent.id), class: "category__parent--name" do
                     = parent.name
                   %ul.category__child.category__list
                     - parent.children.each do |child|
                       %li
-                        = link_to "#", class: "category__child--name" do
+                        = link_to category_path(child.id), class: "category__child--name" do
                           = child.name
                         %ul.category__grandchild.category__list
                           - child.children.each do |grandchild|
                             %li
-                              = link_to "#", class: " category__child--name" do
+                              = link_to category_path(grandchild.id), class: " category__child--name" do
                                 = grandchild.name
       %li.list-left__brand
         =link_to "#", class: "brand-link" do

--- a/app/views/products/show.html.haml
+++ b/app/views/products/show.html.haml
@@ -66,13 +66,13 @@
             %th.detail-left カテゴリー
             - if [46, 74, 134, 142, 147, 150, 158].include?(@category_id)
               %td.detail-right
-                = link_to "#{@category_child.name}","#"
+                = link_to "#{@category_child.name}",category_path(@category_child.id)
                 %br= link_to "#{@category_grandchild.name}","#"
             -else
               %td.detail-right
-                = link_to "#{@category_parent.name}","#"
-                %br= link_to "#{@category_child.name}","#"
-                = link_to "#{@category_grandchild.name}","#"
+                = link_to "#{@category_parent.name}",category_path(@category_parent.id)
+                %br= link_to "#{@category_child.name}",category_path(@category_child.id)
+                = link_to "#{@category_grandchild.name}",category_path(@category_grandchild.id)
           %tr.detail-record
             %th.detail-left ブランド
             %td.detail-right= @product.brand
@@ -143,25 +143,11 @@
             後ろの商品
     .show-main__related-items
       - if [46, 74, 134, 142, 147, 150, 158].include?(@category_id)
-        =link_to "#{@category_child.name}をもっと見る", "#", class:"related-items-link"
+        =link_to "#{@category_child.name}をもっと見る", category_path(@category_child.id), class:"related-items-link"
       - else
-        = link_to "#{@category_parent.name}をもっと見る", "#", class: "related-items-link"
+        = link_to "#{@category_parent.name}をもっと見る", category_path(@category_parent.id), class: "related-items-link"
       .related-items-list
-        .related-item
-          =link_to "#", class: "related-item-link" do
-            %figure.related-item-image-field
-              = image_tag @images_first.src.url, alt:"related-item", class: "related-item-image",height: "87px"
-            .related-item-body
-              = @product.name
-            .related-item-detail
-              %ul.detail-list
-                %li.price
-                  ¥
-                  = @product.price.to_s(:delimited)
-                %li.favorite
-                  =icon("fas","star")
-                  0
-              %p.tax (税込)
+        = render partial:'product', collection: @products
 %aside.appBanner
   = render 'aside'
 .footer


### PR DESCRIPTION
# what
【最終課題追加実装】
・「カテゴリー一覧ページ」実装
・「カテゴリー別詳細ページ」実装
・「商品詳細ページ」内に同カテゴリーの商品が掲載される仕様となっております。
・product/index,showの各リンクから「カテゴリー一覧ページ」、「カテゴリー別詳細ページ」に遷移できるようになっています。
以下参照GIFご確認ください。
[カテゴリー一覧→カテゴリー別詳細](https://gyazo.com/7dede5e8a6ab79a6d6a1f2496a523704)
[カテゴリー別詳細→商品詳細](https://gyazo.com/a78182567bd58d67b562a3a28fb28f4c)

# why
より使い勝手の良いアプリにするため。
コードレビュー宜しくお願いします。